### PR TITLE
feat: implement `ResponseError` trait (actix-web) and removes `InertiaErrMapper` trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,7 @@ use inertia_rust::{actix::render, InertiaErrMapper};
 
 #[get("/")]
 async fn index(req: HttpRequest) -> impl Responder {
-    render::<Vite>(&req, "Index".into())
-        .await
-        .map_inertia_err()
+    render::<Vite>(&req, "Index".into()).await
 }
 
 #[actix_web::main]
@@ -245,9 +243,7 @@ async fn index(req: HttpRequest) -> impl Responder {
         InertiaProp::Always("Hello world!".into()),
     );
 
-    render_with_props::<Vite>(&req, "Index".into(), props)
-        .await
-        .map_inertia_err()
+    render_with_props::<Vite>(&req, "Index".into(), props).await
 }
 
 // ...

--- a/examples/actix_ssr/src/main.rs
+++ b/examples/actix_ssr/src/main.rs
@@ -1,8 +1,7 @@
 use actix_web::{get, web::Data, App, HttpRequest, HttpServer, Responder};
 use inertia_rust::actix::{render_with_props, InertiaMiddleware};
 use inertia_rust::{
-    Inertia, InertiaConfig, InertiaErrMapper, InertiaProp, InertiaService, InertiaVersion,
-    SsrClient,
+    Inertia, InertiaConfig, InertiaProp, InertiaService, InertiaVersion, SsrClient,
 };
 use serde_json::json;
 use std::sync::Arc;
@@ -23,9 +22,7 @@ async fn home(req: HttpRequest) -> impl Responder {
         InertiaProp::Data("This message is sent from the server!".to_string().into()),
     );
 
-    render_with_props::<Vite>(&req, "Index".into(), props)
-        .await
-        .map_inertia_err()
+    render_with_props::<Vite>(&req, "Index".into(), props).await
 }
 
 #[get("/contact")]
@@ -39,9 +36,7 @@ async fn contact(req: HttpRequest) -> impl Responder {
         })),
     );
 
-    render_with_props::<Vite>(&req, "Contact".into(), props)
-        .await
-        .map_inertia_err()
+    render_with_props::<Vite>(&req, "Contact".into(), props).await
 }
 
 static VITE: OnceLock<Vite> = OnceLock::new();

--- a/examples/actix_ssr/src/main.rs
+++ b/examples/actix_ssr/src/main.rs
@@ -1,7 +1,8 @@
 use actix_web::{get, web::Data, App, HttpRequest, HttpServer, Responder};
-use inertia_rust::actix::{render_with_props, InertiaMiddleware, InertiaService};
+use inertia_rust::actix::{render_with_props, InertiaMiddleware};
 use inertia_rust::{
-    Inertia, InertiaConfig, InertiaErrMapper, InertiaProp, InertiaVersion, SsrClient,
+    Inertia, InertiaConfig, InertiaErrMapper, InertiaProp, InertiaService, InertiaVersion,
+    SsrClient,
 };
 use serde_json::json;
 use std::sync::Arc;
@@ -73,10 +74,10 @@ async fn main() -> std::io::Result<()> {
     )?;
 
     let inertia_data = Data::new(inertia);
-    let inertia_data_to_move = Data::clone(&inertia_data);
+    let inertia_clone = Data::clone(&inertia_data);
     let server = HttpServer::new(move || {
         App::new()
-            .app_data(inertia_data_to_move.clone())
+            .app_data(inertia_clone.clone())
             .wrap(
                 InertiaMiddleware::new().with_shared_props(Arc::new(move |_req| {
                     let mut shared_props = HashMap::new();

--- a/src/features/template_resolvers/basic_vite_resolver.rs
+++ b/src/features/template_resolvers/basic_vite_resolver.rs
@@ -2,67 +2,63 @@ use crate::{InertiaError, TemplateResolverOutput, ViewData};
 use std::path::Path;
 use vite_rust::{features::html_directives::ViteDefaultDirectives, Vite};
 
-// The actual template resolver
-// that performs all the logic to render the template
-async fn _resolver(path: &str, view_data: ViewData, vite: &Vite) -> Result<String, InertiaError> {
-    let path = Path::new(path);
-    let file = match tokio::fs::read(&path).await {
-        Ok(file) => file,
-        Err(err) => {
-            return Err(InertiaError::RenderError(format!(
-                "Failed to open root layout at {}: {:#}",
-                path.to_str().unwrap(),
-                err
-            )))
-        }
-    };
-
-    let mut html = match String::from_utf8(file) {
-        Err(err) => {
-            return Err(InertiaError::RenderError(format!(
-                "Failed to read file contents: {err:?}"
-            )))
-        }
-        Ok(html) => html,
-    };
-
-    vite.vite_directive(&mut html);
-    vite.assets_url_directive(&mut html);
-    vite.hmr_directive(&mut html);
-    vite.react_directive(&mut html);
-
-    match &view_data.ssr_page {
-        Some(ssr) => {
-            html = html.replace("@inertia::body", ssr.get_body());
-            html = html.replace("@inertia::head", &ssr.get_head());
-        }
-        None => {
-            let stringified_page: Result<String, serde_json::Error> =
-                serde_json::to_string(&view_data.page);
-
-            if stringified_page.is_err() {
-                return Err(InertiaError::SerializationError(format!(
-                    "Failed to serialize view_data.page: {:?}",
-                    &view_data.page
-                )));
-            }
-
-            let stringified_page = stringified_page.unwrap();
-            let container = format!("<div id='app' data-page='{}'></div>\n", stringified_page,);
-
-            html = html.replace("@inertia::body", &container);
-            html = html.replace("@inertia::head", "");
-        }
-    }
-
-    Ok(html)
-}
-
-// A wrapper for the async resolver
+// The async resolver
 pub fn template_resolver(
     template_path: &'static str,
     view_data: ViewData,
     vite: &'static Vite,
 ) -> TemplateResolverOutput {
-    Box::pin(_resolver(template_path, view_data, vite))
+    Box::pin(async move {
+        let path = Path::new(template_path);
+        let file = match tokio::fs::read(&path).await {
+            Ok(file) => file,
+            Err(err) => {
+                return Err(InertiaError::RenderError(format!(
+                    "Failed to open root layout at {}: {:#}",
+                    path.to_str().unwrap(),
+                    err
+                )))
+            }
+        };
+
+        let mut html = match String::from_utf8(file) {
+            Err(err) => {
+                return Err(InertiaError::RenderError(format!(
+                    "Failed to read file contents: {err:?}"
+                )))
+            }
+            Ok(html) => html,
+        };
+
+        vite.vite_directive(&mut html);
+        vite.assets_url_directive(&mut html);
+        vite.hmr_directive(&mut html);
+        vite.react_directive(&mut html);
+
+        match &view_data.ssr_page {
+            Some(ssr) => {
+                html = html.replace("@inertia::body", ssr.get_body());
+                html = html.replace("@inertia::head", &ssr.get_head());
+            }
+            None => {
+                let stringified_page: Result<String, serde_json::Error> =
+                    serde_json::to_string(&view_data.page);
+
+                if stringified_page.is_err() {
+                    return Err(InertiaError::SerializationError(format!(
+                        "Failed to serialize view_data.page: {:?}",
+                        &view_data.page
+                    )));
+                }
+
+                let stringified_page = stringified_page.unwrap();
+                let container = format!("<div id='app' data-page='{}'></div>\n", stringified_page,);
+
+                html = html.replace("@inertia::body", &container);
+                html = html.replace("@inertia::head", "");
+            }
+        }
+
+        Ok(html)
+    })
 }

--- a/src/inertia.rs
+++ b/src/inertia.rs
@@ -104,10 +104,6 @@ pub trait InertiaResponder<TResponder, THttpRequest> {
     fn location(req: &THttpRequest, url: &str) -> TResponder;
 }
 
-pub trait InertiaErrMapper<TResponder, THttpResponse> {
-    fn map_inertia_err(self) -> TResponder;
-}
-
 /// Defines some helper methods to be implemented to HttpRequests from the
 /// library opted by the cargo feature.
 pub(crate) trait InertiaHttpRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ pub use config::{InertiaConfig, InertiaConfigBuilder};
 pub use error::InertiaError;
 pub use inertia::Component;
 pub use inertia::Inertia;
-pub use inertia::InertiaErrMapper;
 pub use inertia::InertiaService;
 pub use inertia::InertiaVersion;
 pub use inertia::SsrClient;


### PR DESCRIPTION
Inertia render helpers callbacks can be returned directly as an opaque `impl Responder` without calling `.map_inertia_err()`.