### PR TITLE
feat: handle Flash Sessions accross forced-refreshes

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -100,7 +100,11 @@ async fn another_handler(req: SomeHttpRequest, inertia_session: InertiaTemporary
 When the assets versions mismatch, the rendering method should return an
 `Inertia::location` redirect that causes a full-reload.
 
-- [ ] Forward the session to be retrieved by the request triggered by the reload.
+**Solution**
+> Inertia requires you to pass callback during Inertia configuration
+> that is responsible for reflashing the inertia temporary session.
+
+- [x] Forward the session to be retrieved by the request triggered by the reload.
 
 ## Inertia Middleware
 - [x] Allow to **share props** globally;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,7 @@
-use crate::{inertia::TemplateResolver, InertiaVersion, SsrClient};
+use crate::{
+    inertia::{ReflashSession, TemplateResolver},
+    InertiaVersion, SsrClient,
+};
 use serde_json::{Map, Value};
 
 /// A configuration struct for initializing Inertia. You can directly fill the struct or use
@@ -40,6 +43,7 @@ where
     pub with_ssr: bool,
     pub custom_ssr_client: Option<SsrClient>,
     pub view_data: Option<Map<String, Value>>,
+    pub reflash_inertia_session: ReflashSession,
 }
 
 impl<T, V> InertiaConfig<T, V>
@@ -87,6 +91,7 @@ where
     pub with_ssr: bool,
     pub custom_ssr_client: Option<SsrClient>,
     pub view_data: Option<Map<String, Value>>,
+    pub reflash_inertia_session: Option<ReflashSession>,
 }
 
 impl<T, V> Default for InertiaConfigBuilder<T, V>
@@ -136,6 +141,7 @@ where
             view_data: None,
             with_ssr: false,
             custom_ssr_client: None,
+            reflash_inertia_session: None,
         }
     }
 
@@ -171,6 +177,11 @@ where
 
     pub fn set_view_data(mut self, view_data: Map<String, Value>) -> Self {
         self.view_data = Some(view_data);
+        self
+    }
+
+    pub fn set_reflash_fn(mut self, reflash_inertia_session_fn: ReflashSession) -> Self {
+        self.reflash_inertia_session = Some(reflash_inertia_session_fn);
         self
     }
 
@@ -223,6 +234,7 @@ where
             view_data: self.view_data,
             with_ssr: self.with_ssr,
             custom_ssr_client: self.custom_ssr_client,
+            reflash_inertia_session: self.reflash_inertia_session.unwrap_or(Box::new(|_| Ok(()))),
         }
     }
 }
@@ -346,6 +358,7 @@ mod test {
             view_data: None,
             with_ssr: false,
             custom_ssr_client: None,
+            reflash_inertia_session: Box::new(|_| Ok(())),
         };
 
         assert_eq!(&with_builder.url, &directly_initialized.url);

--- a/src/inertia.rs
+++ b/src/inertia.rs
@@ -149,7 +149,7 @@ pub(crate) type TemplateResolver<T> = &'static (dyn Fn(&'static str, ViewData, &
               + 'static);
 
 pub(crate) type ReflashSession =
-    Box<dyn Fn(Option<InertiaTemporarySession>) -> Result<(), InertiaError>>;
+    Box<dyn Fn(Option<InertiaTemporarySession>) -> Result<(), InertiaError> + Send + Sync>;
 
 #[derive(PartialEq, Debug)]
 pub struct SsrClient {

--- a/src/inertia.rs
+++ b/src/inertia.rs
@@ -6,7 +6,7 @@ use crate::config::InertiaConfig;
 use crate::node_process::NodeJsProc;
 use crate::props::InertiaProps;
 use crate::req_type::InertiaRequestType;
-use crate::{InertiaError, InertiaPage, InertiaSSRPage};
+use crate::{InertiaError, InertiaPage, InertiaSSRPage, InertiaTemporarySession};
 use async_trait::async_trait;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -148,6 +148,9 @@ pub(crate) type TemplateResolver<T> = &'static (dyn Fn(&'static str, ViewData, &
               + Sync
               + 'static);
 
+pub(crate) type ReflashSession =
+    Box<dyn Fn(Option<InertiaTemporarySession>) -> Result<(), InertiaError>>;
+
 #[derive(PartialEq, Debug)]
 pub struct SsrClient {
     pub(crate) host: &'static str,
@@ -216,6 +219,20 @@ where
     pub(crate) ssr_url: Option<Url>,
     /// Extra data to be passed to the root template.
     pub(crate) custom_view_data: Map<String, Value>,
+    /// A function that must persist the Inertia temporary session (flash session) for one more request.
+    /// It's up to you to implement, as we have no control over your http framework nor sessions manager.
+    /// Inertia will call this function if the request and the Inertia assets version mismatch, just before
+    /// it forces a redirect.
+    ///
+    /// # Arguments
+    /// Inertia's rendering methods will call this function passing the following parameter(s):
+    /// * `inertia_temporary_session`   -   An `Option<InertiaTemporarySession>`. If `Some`, you should assure it's
+    ///                                     restored in the flash sessions for the next request.
+    ///
+    /// # Errors
+    /// You can return an `InertiaError` from this method if you desire, however, all Inertia will do with
+    /// this error is log it as a warning. It won't stop the rendering method from refreshing the request.
+    pub(crate) reflash_inertia_session: ReflashSession,
 }
 
 impl<T> Inertia<T>
@@ -275,6 +292,7 @@ where
             template_resolver_data: config.template_resolver_data,
             ssr_url,
             custom_view_data: config.view_data.unwrap_or_default(),
+            reflash_inertia_session: config.reflash_inertia_session,
         })
     }
 

--- a/src/providers/actix_provider/impls.rs
+++ b/src/providers/actix_provider/impls.rs
@@ -212,7 +212,7 @@ impl InertiaHttpRequest for HttpRequest {
             .map_or(true, |version| {
                 version
                     .to_str()
-                    .map_or(false, |version| version == current_version)
+                    .is_ok_and(|version| version == current_version)
             })
     }
 }

--- a/src/providers/actix_provider/middleware.rs
+++ b/src/providers/actix_provider/middleware.rs
@@ -1,32 +1,44 @@
+use actix_web::body::EitherBody;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::{Method, StatusCode};
+use actix_web::web::Data;
 use actix_web::Error;
 use actix_web::HttpMessage;
 use futures_util::future::LocalBoxFuture;
 use serde_json::to_value;
 use std::collections::HashMap;
 use std::future::{ready, Ready};
+use std::marker::PhantomData;
 use std::sync::Arc;
 
+use crate::inertia::{InertiaHttpRequest, InertiaResponder};
 use crate::temporary_session::InertiaTemporarySession;
-use crate::{InertiaProp, InertiaProps};
+use crate::{Inertia, InertiaProp, InertiaProps};
 
 type SharedPropsCallback = dyn Fn(&ServiceRequest) -> InertiaProps;
 
-pub struct InertiaMiddleware {
+pub struct InertiaMiddleware<TInertia> {
     shared_props_cb: Arc<SharedPropsCallback>,
+    _p: PhantomData<TInertia>,
 }
 
-impl Default for InertiaMiddleware {
+impl<TInertia> Default for InertiaMiddleware<TInertia>
+where
+    TInertia: 'static,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl InertiaMiddleware {
+impl<TInertia> InertiaMiddleware<TInertia>
+where
+    TInertia: 'static,
+{
     pub fn new() -> Self {
         Self {
             shared_props_cb: Arc::new(|_req| HashMap::new()),
+            _p: PhantomData::<TInertia>,
         }
     }
 
@@ -39,16 +51,17 @@ impl InertiaMiddleware {
 // Middleware factory is `Transform` trait
 // `S` - type of the next service
 // `B` - type of response's body
-impl<S, B> Transform<S, ServiceRequest> for InertiaMiddleware
+impl<S, B, TInertia> Transform<S, ServiceRequest> for InertiaMiddleware<TInertia>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
     B: 'static,
+    TInertia: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
     type InitError = ();
-    type Transform = InertiaMiddlewareService<S>;
+    type Transform = InertiaMiddlewareService<S, TInertia>;
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
@@ -56,24 +69,30 @@ where
         ready(Ok(InertiaMiddlewareService {
             service,
             shared_props: shpcb,
+            _p: PhantomData::<TInertia>,
         }))
     }
 }
 
-pub struct InertiaMiddlewareService<S> {
+pub struct InertiaMiddlewareService<S, TInertia>
+where
+    TInertia: 'static,
+{
     service: S,
     shared_props: Arc<SharedPropsCallback>,
+    _p: PhantomData<TInertia>,
 }
 
 pub(crate) struct SharedProps(pub InertiaProps);
 
-impl<S, B> Service<ServiceRequest> for InertiaMiddlewareService<S>
+impl<S, B, TInertia> Service<ServiceRequest> for InertiaMiddlewareService<S, TInertia>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
     B: 'static,
+    TInertia: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
     type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -82,29 +101,55 @@ where
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let mut shared_props = (self.shared_props)(&req);
 
-        if let Some(request_props) = req.extensions().get::<InertiaTemporarySession>() {
+        let inertia_temporary_session = req.extensions_mut().remove::<InertiaTemporarySession>();
+        if let Some(request_props) = &inertia_temporary_session {
             let errors = to_value(&request_props.errors).unwrap();
             shared_props.insert("errors".into(), InertiaProp::Always(errors));
         }
 
         req.extensions_mut().insert(SharedProps(shared_props));
 
+        let http_req = req.request().clone();
+        let inertia = req.app_data::<Data<Inertia<TInertia>>>().cloned();
+
         let fut: <S as Service<ServiceRequest>>::Future = self.service.call(req);
 
         Box::pin(async move {
-            let mut res: ServiceResponse<B> = fut.await?;
+            // check inertia version and force refresh persisting temporary session
+            let is_latest_version = inertia.map_or(false, |inertia| {
+                http_req.check_inertia_version(inertia.version)
+            });
 
-            let req_method = res.request().method();
-            let res_status = res.status();
+            match is_latest_version {
+                false => {
+                    let response =
+                        Inertia::<TInertia>::location(&http_req, &http_req.uri().to_string());
 
-            if [Method::PATCH, Method::PUT, Method::DELETE].contains(req_method)
-                && (res_status == StatusCode::MOVED_PERMANENTLY || res_status == StatusCode::FOUND)
-            {
-                let res = res.response_mut();
-                *res.status_mut() = StatusCode::SEE_OTHER;
+                    if let Some(session) = inertia_temporary_session {
+                        http_req.extensions_mut().insert(session);
+                    };
+
+                    let res = ServiceResponse::new(http_req, response).map_into_right_body();
+
+                    Ok(res)
+                }
+                true => {
+                    let mut res = fut.await.map(ServiceResponse::map_into_left_body)?;
+
+                    let req_method = res.request().method();
+                    let res_status = res.status();
+
+                    if [Method::PATCH, Method::PUT, Method::DELETE].contains(req_method)
+                        && (res_status == StatusCode::MOVED_PERMANENTLY
+                            || res_status == StatusCode::FOUND)
+                    {
+                        let res = res.response_mut();
+                        *res.status_mut() = StatusCode::SEE_OTHER;
+                    }
+
+                    Ok(res)
+                }
             }
-
-            Ok(res)
         })
     }
 }

--- a/src/providers/actix_provider/middleware.rs
+++ b/src/providers/actix_provider/middleware.rs
@@ -1,44 +1,32 @@
-use actix_web::body::EitherBody;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::{Method, StatusCode};
-use actix_web::web::Data;
 use actix_web::Error;
 use actix_web::HttpMessage;
 use futures_util::future::LocalBoxFuture;
 use serde_json::to_value;
 use std::collections::HashMap;
 use std::future::{ready, Ready};
-use std::marker::PhantomData;
 use std::sync::Arc;
 
-use crate::inertia::{InertiaHttpRequest, InertiaResponder};
 use crate::temporary_session::InertiaTemporarySession;
-use crate::{Inertia, InertiaProp, InertiaProps};
+use crate::{InertiaProp, InertiaProps};
 
 type SharedPropsCallback = dyn Fn(&ServiceRequest) -> InertiaProps;
 
-pub struct InertiaMiddleware<TInertia> {
+pub struct InertiaMiddleware {
     shared_props_cb: Arc<SharedPropsCallback>,
-    _p: PhantomData<TInertia>,
 }
 
-impl<TInertia> Default for InertiaMiddleware<TInertia>
-where
-    TInertia: 'static,
-{
+impl Default for InertiaMiddleware {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<TInertia> InertiaMiddleware<TInertia>
-where
-    TInertia: 'static,
-{
+impl InertiaMiddleware {
     pub fn new() -> Self {
         Self {
             shared_props_cb: Arc::new(|_req| HashMap::new()),
-            _p: PhantomData::<TInertia>,
         }
     }
 
@@ -51,17 +39,16 @@ where
 // Middleware factory is `Transform` trait
 // `S` - type of the next service
 // `B` - type of response's body
-impl<S, B, TInertia> Transform<S, ServiceRequest> for InertiaMiddleware<TInertia>
+impl<S, B> Transform<S, ServiceRequest> for InertiaMiddleware
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
     B: 'static,
-    TInertia: 'static,
 {
-    type Response = ServiceResponse<EitherBody<B>>;
+    type Response = ServiceResponse<B>;
     type Error = Error;
     type InitError = ();
-    type Transform = InertiaMiddlewareService<S, TInertia>;
+    type Transform = InertiaMiddlewareService<S>;
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
@@ -69,30 +56,24 @@ where
         ready(Ok(InertiaMiddlewareService {
             service,
             shared_props: shpcb,
-            _p: PhantomData::<TInertia>,
         }))
     }
 }
 
-pub struct InertiaMiddlewareService<S, TInertia>
-where
-    TInertia: 'static,
-{
+pub struct InertiaMiddlewareService<S> {
     service: S,
     shared_props: Arc<SharedPropsCallback>,
-    _p: PhantomData<TInertia>,
 }
 
 pub(crate) struct SharedProps(pub InertiaProps);
 
-impl<S, B, TInertia> Service<ServiceRequest> for InertiaMiddlewareService<S, TInertia>
+impl<S, B> Service<ServiceRequest> for InertiaMiddlewareService<S>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
     B: 'static,
-    TInertia: 'static,
 {
-    type Response = ServiceResponse<EitherBody<B>>;
+    type Response = ServiceResponse<B>;
     type Error = Error;
     type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -101,55 +82,29 @@ where
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let mut shared_props = (self.shared_props)(&req);
 
-        let inertia_temporary_session = req.extensions_mut().remove::<InertiaTemporarySession>();
-        if let Some(request_props) = &inertia_temporary_session {
+        if let Some(request_props) = req.extensions().get::<InertiaTemporarySession>() {
             let errors = to_value(&request_props.errors).unwrap();
             shared_props.insert("errors".into(), InertiaProp::Always(errors));
         }
 
         req.extensions_mut().insert(SharedProps(shared_props));
 
-        let http_req = req.request().clone();
-        let inertia = req.app_data::<Data<Inertia<TInertia>>>().cloned();
-
         let fut: <S as Service<ServiceRequest>>::Future = self.service.call(req);
 
         Box::pin(async move {
-            // check inertia version and force refresh persisting temporary session
-            let is_latest_version = inertia.map_or(false, |inertia| {
-                http_req.check_inertia_version(inertia.version)
-            });
+            let mut res: ServiceResponse<B> = fut.await?;
 
-            match is_latest_version {
-                false => {
-                    let response =
-                        Inertia::<TInertia>::location(&http_req, &http_req.uri().to_string());
+            let req_method = res.request().method();
+            let res_status = res.status();
 
-                    if let Some(session) = inertia_temporary_session {
-                        http_req.extensions_mut().insert(session);
-                    };
-
-                    let res = ServiceResponse::new(http_req, response).map_into_right_body();
-
-                    Ok(res)
-                }
-                true => {
-                    let mut res = fut.await.map(ServiceResponse::map_into_left_body)?;
-
-                    let req_method = res.request().method();
-                    let res_status = res.status();
-
-                    if [Method::PATCH, Method::PUT, Method::DELETE].contains(req_method)
-                        && (res_status == StatusCode::MOVED_PERMANENTLY
-                            || res_status == StatusCode::FOUND)
-                    {
-                        let res = res.response_mut();
-                        *res.status_mut() = StatusCode::SEE_OTHER;
-                    }
-
-                    Ok(res)
-                }
+            if [Method::PATCH, Method::PUT, Method::DELETE].contains(req_method)
+                && (res_status == StatusCode::MOVED_PERMANENTLY || res_status == StatusCode::FOUND)
+            {
+                let res = res.response_mut();
+                *res.status_mut() = StatusCode::SEE_OTHER;
             }
+
+            Ok(res)
         })
     }
 }

--- a/src/temporary_session.rs
+++ b/src/temporary_session.rs
@@ -7,16 +7,16 @@ use serde_json::{Map, Value};
 /// You must inject it by yourself by a second middleware, which gets these information from
 /// your framework sessions manager.
 #[derive(Clone, Serialize)]
-pub struct InertiaTemporarySession<'a> {
+pub struct InertiaTemporarySession {
     pub errors: Option<Map<String, Value>>,
-    pub prev_req_url: &'a str,
+    pub prev_req_url: String,
 }
 
-impl Default for InertiaTemporarySession<'_> {
+impl Default for InertiaTemporarySession {
     fn default() -> Self {
         InertiaTemporarySession {
             errors: None,
-            prev_req_url: "/",
+            prev_req_url: "/".to_string(),
         }
     }
 }


### PR DESCRIPTION
If the request Inertia's version mismatches the latest one, it would force a refresh with `Inertia::location`. Now, it's possible to pass a callback during `Inertia` config that will be called during the version mismatch handling, reflashing the temporary sessions so that it is handled by the actual request.