### PR TITLE
feat: add new template resolver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "rust-analyzer.cargo.features": [
         "actix",
         "vite-template-resolver",
+        "vite-hbs-template-resolver",
         "validator",
         "actix-validator"
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
 ## Unreleased
+### Added
+- `ViteHBSTemplateResolver`, which uses Handlebars as template engine.
+
 ### Changed
-- Merge `inner_render` and `inner_render_with_props` methods.
+- Merged `inner_render` and `inner_render_with_props` methods;
+- Updated the docs for using `ViteHBSTemplateResolver` by default;
+- Deprecated `ViteTemplateResolver`.
 
 ### Removed
 - `template_path` field and setters from `Inertia` and `InertiaConfigBuilder`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 ### Changed
 - Merge `inner_render` and `inner_render_with_props` methods.
 
+### Removed
+- `template_path` field and setters from `Inertia` and `InertiaConfigBuilder`;
+
+### Breaking
+#### Template Resolvers
+`template_path` has been removed from Inertia struct. Now, it's the template resolver's responsability to fetch and
+parse the template HTML. This means `ViteTemplateResolver` now is the one who takes the template path on initialization.
+
+Also, its `new` method now returns a `Result<ViteTemplateResolver, InertiaError>` instead of `ViteTemplateResolver`
+directly, since it looks for the root template in the given path and return an error if it can't find the file.
+
+```diff
+let vite = initialize_vite().await;
+- let resolver = ViteTemplateResolver::new(vite);
++ let resolver = ViteTemplateResolver::new(vite, "www/root.html").unwrap();
+
+let inertia = Inertia::new(
+    InertiaConfig::builder()
+        .set_url("http://localhost:8080")
+        .set_version(InertiaVersion::Literal(ASSETS_VERSION.get().unwrap()))
+-        .set_template_path("www/root.html")
+        .set_template_resolver(Box::new(resolver))
+        .enable_ssr()
+        .set_ssr_client(SsrClient::new("127.0.0.1", 1000))
+        .build(),
+);
+```
+
 ## v2.3.8
 ### Fixed
 - Add `Vary: X-Inertia` header to Inertia responses. This fixes some cache-related issues (for instance, a plain JSON

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,12 +423,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -680,6 +746,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6b224b95c1e668ac0270325ad563b2eef1469fbbb8959bc7c692c844b813d9"
+dependencies = [
+ "derive_builder",
+ "log",
+ "num-order",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +960,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-util",
+ "handlebars",
  "log",
  "regex",
  "reqwest",
@@ -1043,6 +1132,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "object"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1247,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1518,6 +1667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,9 +1737,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1621,6 +1787,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1790,6 +1976,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ exclude = [
 
 [features]
 actix = ["dep:actix-web"]
-vite-template-resolver = ["dep:vite-rust"]
+vite-template-resolver = ["vite-rust/basic-directives", "dep:regex"]
+vite-hbs-template-resolver = ["dep:vite-rust", "dep:handlebars"]
 actix-validator = ["dep:actix-web", "validator"]
 validator = ["dep:validator"]
 
@@ -31,7 +32,8 @@ log = "0.4"
 tokio = { version = "~1", features = ["fs", "io-std", "test-util", "rt", "macros"] }
 futures = "~0.3.30"
 actix-web = { version = "~4", features = ["default"], optional = true }
-vite-rust = { version = "~0.2", optional = true, features = ["basic-directives"] }
+vite-rust = { version = "~0.2", optional = true }
 futures-util = "~0.3.31"
-regex = "1"
+regex = { version = "1", optional = true}
 validator = { version = ">= 0.9, < 1", optional = true }
+handlebars = { version = "6", optional = true }

--- a/docs/src/advanced/template_resolvers.md
+++ b/docs/src/advanced/template_resolvers.md
@@ -74,3 +74,21 @@ impl TemplateResolver for ViteTemplateResolver {
 
 Naturally, there is no untreated `.unwrap()` or `.expect()` in the built-in template resolvers, and every error is
 properly handled.
+
+## The Vite and Handlebars Template Resolver
+
+This template resolver is enabled through the `vite-hbs-template-resolver` feature. It uses [Handlebars], one of the most reliable and production-ready template engines available for Rust.
+
+Through this template resolver, we expose a bunch of properties to you:
+
+- `inertia_head`: the head of your Inertia page component.
+- `inertia_body`: the body of your Inertia page component.
+- `page`: a HashMap containing all of your Inertia page component props (yes, you can directly access them from your
+    template like `page.user.name`, if it's a valid prop sent from your back-end).
+- `view_data`: a HashMap containing the view data custom props. You provide it by using `Inertia::view_data()` method.
+    Check [the Response guide] for more details.
+- `vite`: the vite scripts (already resolved according to the environment [development or production]).
+- `vite_react_refresh`: the script for refreshing your React application on development.
+
+[Handlebars]: https://crates.io/crates/handlebars
+[the Response guide]: ../basic/responses.md#root-template-data

--- a/docs/src/advanced/template_resolvers.md
+++ b/docs/src/advanced/template_resolvers.md
@@ -4,18 +4,23 @@ Template resolvers are structs that implements Inertia Rust's `TemplateResolver`
 for rendering the root template from your application. Specially, for injecting Inertia.js head and body
 into the HTML.
 
+In summary, a template resolver has the following responsabilities:
+- Inject assets tags (e.g. script, css and link tags), usually via some bundler;
+- Inject Inertia SSRrendered head (or nothing if CSRendered);
+- Inject Inertia body (SSR or CSRendered);
+- Inject custom view data (if any).
+
 For instance, the default `ViteTemplateResolver` (available when `vite-template-resolver` feature is enabled)
 will use Vite Rust crate to inject the correct HTML tags for the application assets in the HTML (e.g.: React.js
-scripts, the application entrypoint script, stylesheets links, preload tags, etc). Also, it'll handle server-
-side rendering and correctly insert Inertia's body and head in the template (if it's SSRendered) or the
-`InertiaPage` in the container element (if CSRendered).
+scripts, the application entrypoint script, stylesheets links, preload tags, etc). For handling the other
+responsabilities, it uses simple REGEXes to parse the available directives.
 
 ## Creating a Template Resolver
 
 You can create your own template resolver pretty easily. All you need to do is create a struct with whatever
 data your template resolver needs to render a page. Then, implement `TemplateResolver` trait for it.
 
-For instance, this is a short of `ViteTemplateResolver`:
+For example, this is a short of `ViteTemplateResolver`:
 
 ```rust
 use crate::{template_resolvers::TemplateResolver, InertiaError, ViewData};
@@ -23,13 +28,18 @@ use async_trait::async_trait;
 use std::path::Path;
 use vite_rust::{features::html_directives::ViteDefaultDirectives, Vite};
 
+// It can contain anything you might need to resolve the template
 pub struct ViteTemplateResolver {
     pub vite: Vite,
+    template_root: String
 }
 
 impl ViteTemplateResolver {
-    pub fn new(vite: Vite) -> Self {
-        Self { vite }
+    pub fn new(vite: Vite, template_path: &str) -> Self {
+        let file = std::fs::read(template_path).expect("file {} should exist.", template_path);
+        let template_root = String::from_utf8(file).expect("template file should contain a valid utf-8 encoded text.");
+
+        Ok(Self { vite, template_root })
     }
 }
 
@@ -37,13 +47,9 @@ impl ViteTemplateResolver {
 impl TemplateResolver for ViteTemplateResolver {
     async fn resolve_template(
         &self,
-        template_path: &str,
         view_data: ViewData<'_>,
     ) -> Result<String, InertiaError> {
-        let path = Path::new(template_path);
-        let file = match tokio::fs::read(&path).await.unwrap();
-
-        let mut html = String::from_utf8(file).unwrap()
+        let mut html = self.template_root.clone();
 
         let _ self.vite.vite_directive(&mut html);
         self.vite.assets_url_directive(&mut html);
@@ -66,5 +72,5 @@ impl TemplateResolver for ViteTemplateResolver {
 }
 ```
 
-Naturally, there is no untreated `.unwrap()` in the official `ViteTemplateResolver`, and every error is
+Naturally, there is no untreated `.unwrap()` or `.expect()` in the built-in template resolvers, and every error is
 properly handled.

--- a/docs/src/basic/installation.md
+++ b/docs/src/basic/installation.md
@@ -7,23 +7,23 @@ provider, assure the needed peer crate is also available.
 # Cargo.toml
 
 [dependencies]
-inertia-rust = { version = "2", features = ["actix", "vite-template-resolver"] }
+inertia-rust = { version = "2", features = ["actix", "vite-hbs-template-resolver"] }
 actix-web = "4"
 vite-rust = { version = "0.2" }
 ```
 
-The **vite-template-resolver** feature enables the `ViteTemplateResolver`. We'll discuss it furthermore, in the
+The **vite-hbs-template-resolver** feature enables the `ViteHBSTemplateResolver`. We'll discuss it furthermore, in the
 [Template Resolvers], along with how to set up your own template resolver. On this documentation, we'll use
 [vite-rust] and [Actix Web], so you must have them installed.
 
 [Template Resolvers]: ../advanced/template_resolvers.md
-[vite-rust]: https://github.com/KaioFelps/vite-rust
 [Actix Web]: https://actix.rs/
 
 ## Available Crate Features
 
 * `actix`: enable Actix Web provider;
-* `vite-template-resolver`: enable `ViteTemplateResolver`;
+* `vite-template-resolver`: enable `ViteTemplateResolver` *\(deprecated\)*;
+* `vite-hbs-template-resolver`: enable `ViteHBSTemplateResolver`;
 * `actix-validator`: enable `InertiaValidateOrRedirect` trait + implementation for actix web's `HttpRequest` and `Redirect` and with `validator` create.
 
 ## Vite Setup
@@ -58,14 +58,24 @@ pub async fn initialize_vite() -> Vite {
 // src/config/inertia.rs
 use super::vite::initialize_vite;
 use inertia_rust::{
-    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaError, InertiaVersion,
+    template_resolvers::ViteHBSTemplateResolver, Inertia, InertiaConfig, InertiaError,
+    InertiaVersion,
 };
 use std::io;
+use vite_rust::ViteMode;
 
 pub async fn initialize_inertia() -> Result<Inertia, io::Error> {
     let vite = initialize_vite().await;
     let version = vite.get_hash().unwrap_or("development").to_string();
-    let resolver = ViteTemplateResolver::new(vite, "www/root.html").map_err(InertiaError::to_io_error)?;
+    let dev_mode = *vite.mode() == ViteMode::Development;
+
+    let resolver = ViteHBSTemplateResolver::builder()
+        .set_vite(vite)
+        .set_template_path("www/root.hbs") // the path to your root handlebars template
+        .set_dev_mode(dev_mode)
+        .build()
+        .map_err(InertiaError::to_io_error)?;
+
 
     Inertia::new(
         InertiaConfig::builder()
@@ -83,7 +93,6 @@ pub async fn initialize_inertia() -> Result<Inertia, io::Error> {
 | ---               | ---                                       | ---           |
 | url               | `&str`                                    | A valid [href](https://developer.mozilla.org/en-US/docs/Web/API/Location) of the current application |
 | version           | `InertiaVersion`                          | The current asset version of the application. See [Asset versioning](https://inertiajs.com/asset-versioning) for more details. |
-| template_path     | `&str`                                    | The path to the root html template. |
 | template_resolver | `Box<dyn TemplateResolver + Send + Sync>` | A valid [Template Resolver]. |
 | with_ssr          | `bool` (`false`)                          | Whether Server-side Rendering should be enabled or not. |
 | custom_ssr_client | `Option<SsrClient>` (`SsrClient::default`)| The Inertia Server address. |
@@ -123,9 +132,37 @@ async fn main() -> std::io::Result<()> {
 ```
 
 ## Root Template
-`ViteTemplateResolver` receives a path to an HTML template file. Inertia Rust will pass the given `template_path`
-to the resolver. In this case, it's `www/root.html` file.
+`ViteHBSTemplateResolver` receives a path to an handlebars template file. It will read this file and keep the content
+in-memory for rendering it on every request. Your template will look like this:
 
+```hbs
+<!doctype html>
+<html lang="en" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+    {{!-- only include this line if you're using react --}}
+    {{{ vite_react_refresh }}}
+    {{{ vite }}}
+    {{{ inertia_head }}}
+</head>
+<body class="h-full">
+    {{{ inertia_body }}}
+</body>
+</html>
+```
+
+There are a few more data you can access on your template. Refer to [`ViteHBSTemplateResolver`] specific section
+to check them out.
+
+<details open>
+    <summary summary>For the deprecated <i>ViteTemplateResolver</i>, the template is a little bit different.</summary>
+   
 ```html
 <!-- www/root.html -->
 <!doctype html>
@@ -144,6 +181,10 @@ to the resolver. In this case, it's `www/root.html` file.
 </body>
 </html>
 ```
+
+</details>
+
+[`ViteHBSTemplateResolver`]: ../advanced/template_resolvers.md#the-vite-and-handlebars-template-resolver
 
 ## Inertia Middleware
 

--- a/docs/src/basic/installation.md
+++ b/docs/src/basic/installation.md
@@ -58,20 +58,19 @@ pub async fn initialize_vite() -> Vite {
 // src/config/inertia.rs
 use super::vite::initialize_vite;
 use inertia_rust::{
-    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaVersion,
+    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaError, InertiaVersion,
 };
 use std::io;
 
 pub async fn initialize_inertia() -> Result<Inertia, io::Error> {
     let vite = initialize_vite().await;
     let version = vite.get_hash().unwrap_or("development").to_string();
-    let resolver = ViteTemplateResolver::new(vite);
+    let resolver = ViteTemplateResolver::new(vite, "www/root.html").map_err(InertiaError::to_io_error)?;
 
     Inertia::new(
         InertiaConfig::builder()
             .set_url("http://localhost:3000")
             .set_version(InertiaVersion::Literal(version))
-            .set_template_path("www/root.html")
             .set_template_resolver(Box::new(resolver))
             .build(),
     )

--- a/docs/src/basic/responses.md
+++ b/docs/src/basic/responses.md
@@ -132,7 +132,13 @@ After calling the `view_data` method, you can access the defined data in your te
 way:
 
 ```html
+<!-- using the deprecated ViteTemplateResolver, in a .html file -->
 <meta name="description" content="@inertia::view_data(meta)">
+```
+
+```hbs
+{{!-- using the ViteHBSTemplateResolver, in a .hbs file --}}
+<meta name="description" content="{{ view_data.meta }}">
 ```
 
 If the value isn't defined, ViteTemplateResolver replaces the value by an ordinary JavaSript `null`.

--- a/docs/src/basic/ssr.md
+++ b/docs/src/basic/ssr.md
@@ -77,3 +77,38 @@ async fn main() -> std::io::Result<()> {
 
 Indeed, you can replace `let _ = node.kill().await;` with `std::mem::drop(node.kill())`, but `.await`ing it
 guarantees the process is killed.
+
+Inertia always inserts a view data property `isSsr` (or even `is_ssr`), which is a boolean value representing
+if the page has been server-side rendered or not.
+
+You might use it on your `app.tsx` to conditionally *hydrate* or *create* your front-end according to the
+response being or not SSRendered.
+
+Adds the following meta tag on your root template's `head` element:
+```hbl
+<meta name="ssr" content="{{ view_data.is_ssr }}">
+```
+
+Then, in your `app.ts|js|tsx|jsx` file, add the follow condition:
+```ts
+import "./app.scss";
+
+import { createInertiaApp } from "@inertiajs/react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+
+createInertiaApp({
+  // ...
+  setup({ el, App, props }) {
+    const isSSR = document.head
+      .querySelector("meta[name='ssr']")?
+      .getAttribute("content") === "true" ?? false;
+
+    if (isSSR) {
+      hydrateRoot(el, <App {...props} />);
+      return;
+    }
+
+    createRoot(el).render(<App {...props} />);
+  },
+});
+```

--- a/docs/src/basic/ssr.md
+++ b/docs/src/basic/ssr.md
@@ -15,29 +15,30 @@ First of all, enable SSR in your Inertia initialization function:
 // src/config/inertia.rs
 use super::vite::initialize_vite;
 use inertia_rust::{
-    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaVersion, SsrClient,
+    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaError, InertiaVersion,
+    SsrClient,
 };
 use std::io;
 
 pub async fn initialize_inertia() -> Result<Inertia, io::Error> {
-    let vite = Arc::new(initialize_vite().await);
+    let vite = initialize_vite().await;
     let version = vite.get_hash().unwrap_or("development").to_string();
-    let resolver = ViteTemplateResolver::new(vite.clone());
+    let resolver = ViteTemplateResolver::new(vite, "www/root.html").map_err(InertiaError::to_io_error)?;
 
     Inertia::new(
         InertiaConfig::builder()
             .set_url("http://localhost:3000")
             .set_version(InertiaVersion::Literal(version))
-            .set_template_path("www/root.html")
             .set_template_resolver(Box::new(resolver))
             
-            // note these two lines
+            // note these two lines ---
 
             .enable_ssr()
             // `set_ssr_client` is optional. If not set, `SsrClient::default()` will be used,
             // which is is "127.0.0.1:13714"
             .set_ssr_client(SsrClient::new("127.0.0.1", 1000))
 
+            // ---
             .build())
 }
 ```

--- a/docs/src/props/deferred.md
+++ b/docs/src/props/deferred.md
@@ -39,8 +39,8 @@ create a custom group, call `InertiaProp::defer_with_group` passing the group na
 #[get("/users")]
 pub async fn users(req: HttpRequest) -> impl Responder {
     Inertia::render(&req, "Users/Index", hashmap![
-        'users' => User::all(),
-        'roles' => Role::all(),
+        'users' => InertiaProp::data(User::all().await),
+        'roles' => InertiaProp::data(Role::all().await),
         'permissions' => InertiaProp::defer(prop_resolver!({ Permission::all().await.into_inertia_value() })),
         'teams' => InertiaProp::defer_with_group(prop_resolver!({ Team::all().await.into_inertia_value() }), 'attributes'),
         'projects' => InertiaProp::defer_with_group(prop_resolver!({ Project::all().await.into_inertia_value() }), 'attributes'),

--- a/examples/actix_ssr/Cargo.lock
+++ b/examples/actix_ssr/Cargo.lock
@@ -563,6 +563,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +879,22 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "handlebars"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6b224b95c1e668ac0270325ad563b2eef1469fbbb8959bc7c692c844b813d9"
+dependencies = [
+ "derive_builder",
+ "log",
+ "num-order",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1166,12 +1213,13 @@ dependencies = [
 
 [[package]]
 name = "inertia-rust"
-version = "2.3.7"
+version = "2.3.8"
 dependencies = [
  "actix-web",
  "async-trait",
  "futures",
  "futures-util",
+ "handlebars",
  "log",
  "regex",
  "reqwest",
@@ -1353,6 +1401,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1508,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1831,6 +1939,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +2077,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2121,6 +2260,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/examples/actix_ssr/Cargo.toml
+++ b/examples/actix_ssr/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-inertia-rust = { path = "../../", features = ["actix", "vite-template-resolver", "actix-validator"] }
+inertia-rust = { path = "../../", features = ["actix", "vite-template-resolver", "vite-hbs-template-resolver", "actix-validator"] }
 actix-web = "4"
 tokio = { version = "1.40.0", features = ["fs", "io-std", "test-util", "rt", "rt-multi-thread", "macros"] }
 serde_json = "1.0"

--- a/examples/actix_ssr/src/config/inertia.rs
+++ b/examples/actix_ssr/src/config/inertia.rs
@@ -1,22 +1,21 @@
-use std::io;
-
-use inertia_rust::{
-    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaVersion, SsrClient,
-};
-
 use crate::ASSETS_VERSION;
+use inertia_rust::{
+    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaError, InertiaVersion,
+    SsrClient,
+};
+use std::io;
 
 use super::vite::initialize_vite;
 
 pub async fn initialize_inertia() -> Result<Inertia, io::Error> {
     let vite = initialize_vite().await;
-    let resolver = ViteTemplateResolver::new(vite);
+    let resolver =
+        ViteTemplateResolver::new(vite, "www/root.html").map_err(InertiaError::to_io_error)?;
 
     Inertia::new(
         InertiaConfig::builder()
             .set_url("http://localhost:8080")
             .set_version(InertiaVersion::Literal(ASSETS_VERSION.get().unwrap()))
-            .set_template_path("www/root.html")
             .set_template_resolver(Box::new(resolver))
             .enable_ssr()
             .set_ssr_client(SsrClient::new("127.0.0.1", 1000))

--- a/examples/actix_ssr/src/config/inertia.rs
+++ b/examples/actix_ssr/src/config/inertia.rs
@@ -1,16 +1,24 @@
 use crate::ASSETS_VERSION;
 use inertia_rust::{
-    template_resolvers::ViteTemplateResolver, Inertia, InertiaConfig, InertiaError, InertiaVersion,
-    SsrClient,
+    template_resolvers::ViteHBSTemplateResolver, Inertia, InertiaConfig, InertiaError,
+    InertiaVersion, SsrClient,
 };
 use std::io;
+use vite_rust::ViteMode;
 
 use super::vite::initialize_vite;
 
 pub async fn initialize_inertia() -> Result<Inertia, io::Error> {
     let vite = initialize_vite().await;
-    let resolver =
-        ViteTemplateResolver::new(vite, "www/root.html").map_err(InertiaError::to_io_error)?;
+
+    let dev_mode = *vite.mode() == ViteMode::Development;
+
+    let resolver = ViteHBSTemplateResolver::builder()
+        .set_vite(vite)
+        .set_template_path("www/root.hbs")
+        .set_dev_mode(dev_mode)
+        .build()
+        .map_err(InertiaError::to_io_error)?;
 
     Inertia::new(
         InertiaConfig::builder()

--- a/examples/actix_ssr/www/root.hbs
+++ b/examples/actix_ssr/www/root.hbs
@@ -1,5 +1,3 @@
-<!-- DEPRECATED: this is the template for the deprecated `ViteTemplateResolver`. Now,
-this sample application uses the handlebars resolver, and thus, a handlebar template file. -->
 <!doctype html>
 <html lang="en" class="h-full">
 <head>
@@ -10,11 +8,12 @@ this sample application uses the handlebars resolver, and thus, a handlebar temp
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    @vite::react
-    @vite
-    @inertia::head
+    <meta name="ssr" content="{{ view_data.is_ssr }}">
+    {{{ vite_react_refresh }}}
+    {{{ vite }}}
+    {{{ inertia_head }}}
 </head>
 <body class="h-full">
-    @inertia::body
+    {{{ inertia_body }}}
 </body>
 </html>

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,6 @@ use crate::{template_resolver::TemplateResolver, InertiaVersion, SsrClient};
 /// * `version`                 -   The current asset version of the application.
 ///                                 See [Asset versioning](https://inertiajs.com/asset-versioning) for more
 ///                                 details.
-/// * `template_path`           -   The path to the root html template.
 /// * `template_resolver`       -   A valid template resolver. Check [Template Resolvers] chapter for more details.
 /// * `with_ssr`                -   Whether Server-side Rendering should be enabled or not.
 /// * `custom_ssr_client`       -   An [`Option<SsrClient>`] with the Inertia Server address.
@@ -29,7 +28,6 @@ where
 {
     pub url: &'static str,
     pub version: InertiaVersion<V>,
-    pub template_path: &'static str,
     pub template_resolver: Box<dyn TemplateResolver + Send + Sync>,
     pub with_ssr: bool,
     pub custom_ssr_client: Option<SsrClient>,
@@ -53,7 +51,6 @@ where
     /// #   impl TemplateResolver for YourTemplateResolver {
     /// #       async fn resolve_template(
     /// #           &self,
-    /// #           template_path: &str,
     /// #           view_data: ViewData<'_>,
     /// #       ) -> Result<String, InertiaError> {
     /// #           // import the layout root and render it using your template engine
@@ -65,7 +62,6 @@ where
     /// let inertia_config = InertiaConfig::builder()
     ///     .set_url("http://localhost:8080")
     ///     .set_version(InertiaVersion::Literal("v1"))
-    ///     .set_template_path("path/to/template.html")
     ///     .set_template_resolver(Box::new(YourTemplateResolver))
     ///     .build();
     /// ```
@@ -80,7 +76,6 @@ where
 {
     pub url: Option<&'static str>,
     pub version: Option<InertiaVersion<V>>,
-    pub template_path: Option<&'static str>,
     pub template_resolver: Option<Box<dyn TemplateResolver + Send + Sync>>,
     pub with_ssr: bool,
     pub custom_ssr_client: Option<SsrClient>,
@@ -113,7 +108,6 @@ where
     /// #   impl TemplateResolver for YourTemplateResolver {
     /// #       async fn resolve_template(
     /// #           &self,
-    /// #           template_path: &str,
     /// #           view_data: ViewData<'_>,
     /// #       ) -> Result<String, InertiaError> {
     /// #           // import the layout root and render it using your template engine
@@ -125,7 +119,6 @@ where
     /// let inertia_config = InertiaConfigBuilder::new()
     ///     .set_url("http://localhost:8080")
     ///     .set_version(InertiaVersion::Literal("v1"))
-    ///     .set_template_path("path/to/template.html")
     ///     .set_template_resolver(Box::new(YourTemplateResolver))
     ///     .build();
     /// ```
@@ -133,7 +126,6 @@ where
         Self {
             url: None,
             version: None,
-            template_path: None,
             template_resolver: None,
             with_ssr: false,
             custom_ssr_client: None,
@@ -153,11 +145,6 @@ where
 
     pub fn set_version(mut self, version: InertiaVersion<V>) -> Self {
         self.version = Some(version);
-        self
-    }
-
-    pub fn set_template_path(mut self, template_path: &'static str) -> Self {
-        self.template_path = Some(template_path);
         self
     }
 
@@ -184,18 +171,12 @@ where
     /// # Panics
     /// Panics if any of the following fields equal [`None`]:
     /// * `url`
-    /// * `template_path`
     /// * `template_resolver`
     /// * `version`
     pub fn build(self) -> InertiaConfig<V> {
         if self.url.is_none() {
             panic!(
             "[InertiaConfigBuilder] 'url' is a mandatory field and InertiaConfigBuilder cannot build without it.");
-        }
-
-        if self.template_path.is_none() {
-            panic!(
-            "[InertiaConfigBuilder] 'template_path' is a mandatory field and InertiaConfigBuilder cannot build without it.");
         }
 
         if self.template_resolver.is_none() {
@@ -210,7 +191,6 @@ where
 
         InertiaConfig {
             url: self.url.unwrap(),
-            template_path: self.template_path.unwrap(),
             template_resolver: self.template_resolver.unwrap(),
             version: self.version.unwrap(),
             with_ssr: self.with_ssr,
@@ -234,11 +214,7 @@ mod test {
 
     #[async_trait::async_trait(?Send)]
     impl TemplateResolver for MyTemplateResolver {
-        async fn resolve_template(
-            &self,
-            _path: &str,
-            _view_data: ViewData<'_>,
-        ) -> Result<String, InertiaError> {
+        async fn resolve_template(&self, _view_data: ViewData<'_>) -> Result<String, InertiaError> {
             Ok("".to_string())
         }
     }
@@ -257,7 +233,6 @@ mod test {
         let build_without_url = panic::catch_unwind(move || {
             InertiaConfigBuilder::<&str>::new()
                 .set_template_resolver(Box::new(MyTemplateResolver))
-                .set_template_path("path")
                 .set_version(InertiaVersion::Literal("v1"))
                 .build()
         });
@@ -265,15 +240,6 @@ mod test {
         let build_without_template_resolver = panic::catch_unwind(move || {
             InertiaConfigBuilder::<&str>::new()
                 .set_url("foo")
-                .set_template_path("path")
-                .set_version(InertiaVersion::Literal("v1"))
-                .build()
-        });
-
-        let build_without_template_path = panic::catch_unwind(move || {
-            InertiaConfigBuilder::<&str>::new()
-                .set_url("foo")
-                .set_template_resolver(Box::new(MyTemplateResolver))
                 .set_version(InertiaVersion::Literal("v1"))
                 .build()
         });
@@ -282,7 +248,6 @@ mod test {
             InertiaConfigBuilder::<&str>::new()
                 .set_url("foo")
                 .set_template_resolver(Box::new(MyTemplateResolver))
-                .set_template_path("path")
                 .build()
         });
 
@@ -290,7 +255,6 @@ mod test {
             InertiaConfigBuilder::<&str>::new()
                 .set_url("foo")
                 .set_template_resolver(Box::new(MyTemplateResolver))
-                .set_template_path("path")
                 .set_version(InertiaVersion::Literal("v1"))
                 .build()
         });
@@ -299,7 +263,6 @@ mod test {
         assert!(build_totally_empty.is_err());
         assert!(build_without_url.is_err());
         assert!(build_without_template_resolver.is_err());
-        assert!(build_without_template_path.is_err());
         assert!(build_without_version.is_err());
         assert!(build_with_critical_fields_filled.is_ok());
     }
@@ -309,14 +272,12 @@ mod test {
         let with_builder = InertiaConfigBuilder::<&str>::new()
             .set_url("foo")
             .set_template_resolver(Box::new(MyTemplateResolver))
-            .set_template_path("path")
             .set_version(InertiaVersion::Literal("v1"))
             .build();
 
         let directly_initialized = InertiaConfig {
             url: "foo",
             template_resolver: Box::new(MyTemplateResolver),
-            template_path: "path",
             version: InertiaVersion::Literal("v1"),
             with_ssr: false,
             custom_ssr_client: None,
@@ -324,10 +285,6 @@ mod test {
         };
 
         assert_eq!(&with_builder.url, &directly_initialized.url);
-        assert_eq!(
-            &with_builder.template_path,
-            &directly_initialized.template_path
-        );
         assert_eq!(
             &with_builder.version.resolve(),
             &directly_initialized.version.resolve()

--- a/src/features/template_resolvers/mod.rs
+++ b/src/features/template_resolvers/mod.rs
@@ -3,3 +3,9 @@ mod vite_template_resolver;
 
 #[cfg(feature = "vite-template-resolver")]
 pub use vite_template_resolver::ViteTemplateResolver;
+
+#[cfg(feature = "vite-hbs-template-resolver")]
+mod vite_hbs_template_resolver;
+
+#[cfg(feature = "vite-hbs-template-resolver")]
+pub use vite_hbs_template_resolver::ViteHBSTemplateResolver;

--- a/src/features/template_resolvers/mod.rs
+++ b/src/features/template_resolvers/mod.rs
@@ -2,6 +2,7 @@
 mod vite_template_resolver;
 
 #[cfg(feature = "vite-template-resolver")]
+#[allow(deprecated)]
 pub use vite_template_resolver::ViteTemplateResolver;
 
 #[cfg(feature = "vite-hbs-template-resolver")]

--- a/src/features/template_resolvers/vite_hbs_template_resolver.rs
+++ b/src/features/template_resolvers/vite_hbs_template_resolver.rs
@@ -1,0 +1,332 @@
+use async_trait::async_trait;
+use handlebars::Handlebars;
+use serde_json::json;
+use vite_rust::{Vite, ViteMode};
+
+use crate::{template_resolver::TemplateResolver, InertiaError, ViewData};
+
+struct ViteStaticSerializedTags {
+    pub scripts: &'static str,
+    pub react_script: Option<&'static str>,
+}
+
+/// Vite HBS stands for Vite and Handlebars. This is a template resolver that also uses Vite Rust
+/// as assets bundler, but, instead of simple regexes, it uses Handlebars as underlying template
+/// engine for rendering the root template more efficiently.
+pub struct ViteHBSTemplateResolver<'a> {
+    pub vite: Vite,
+    pub hbs: Handlebars<'a>,
+    static_tags: ViteStaticSerializedTags,
+}
+
+impl<'a> ViteHBSTemplateResolver<'a> {
+    pub fn new(vite: Vite, template_path: &'a str, dev_mode: bool) -> Result<Self, InertiaError> {
+        let mut hbs = Handlebars::new();
+
+        hbs.set_dev_mode(dev_mode);
+
+        if let Err(err) = hbs.register_template_file("root", template_path) {
+            return Err(InertiaError::RenderError(format!(
+                "Failed to register template path: {}",
+                err.reason()
+            )));
+        }
+
+        let static_tags = Self::get_static_tags(&vite)?;
+
+        Ok(Self {
+            hbs,
+            vite,
+            static_tags,
+        })
+    }
+
+    #[inline]
+    pub fn builder() -> ViteHBSTemplateResolverBuilder<'a> {
+        ViteHBSTemplateResolverBuilder::new()
+    }
+
+    #[inline]
+    fn from_builder(builder: ViteHBSTemplateResolverBuilder<'a>) -> Result<Self, InertiaError> {
+        let vite = builder.vite.expect("Vite hasn't been set. Please, ensure you've correctly configured the ViteHBSTemplateResolverBuilder.");
+        let template_path = builder.template_path.expect("Template path hasn't been set. Please, ensure you've correctly configured the ViteHBSTemplateResolverBuilder.");
+
+        if let Some(hbs) = builder.hbs {
+            let static_tags = Self::get_static_tags(&vite)?;
+
+            return Ok(Self {
+                vite,
+                hbs,
+                static_tags,
+            });
+        }
+
+        Self::new(vite, template_path, builder.dev_mode)
+    }
+
+    #[inline]
+    fn get_static_tags(vite: &Vite) -> Result<ViteStaticSerializedTags, InertiaError> {
+        let resolved_scripts = vite.get_resolved_vite_scripts().map_err(|err| {
+            InertiaError::RenderError(format!("Failed to resolve vite scripts: {err}"))
+        })?;
+
+        Ok(ViteStaticSerializedTags {
+            react_script: match vite.mode() {
+                ViteMode::Manifest => None,
+                ViteMode::Development => Some(Box::leak(vite.get_react_script().into_boxed_str())),
+            },
+            scripts: Box::leak(resolved_scripts.into_boxed_str()),
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct ViteHBSTemplateResolverBuilder<'a> {
+    pub vite: Option<Vite>,
+    pub hbs: Option<Handlebars<'a>>,
+    pub template_path: Option<&'a str>,
+    pub dev_mode: bool,
+}
+
+impl<'a> ViteHBSTemplateResolverBuilder<'a> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_custom_handlebars(mut self, hbs: Handlebars<'a>) -> Self {
+        self.hbs = Some(hbs);
+        self
+    }
+
+    pub fn set_vite(mut self, vite: Vite) -> Self {
+        self.vite = Some(vite);
+        self
+    }
+
+    pub fn set_template_path(mut self, template_path: &'a str) -> Self {
+        self.template_path = Some(template_path);
+        self
+    }
+
+    pub fn set_dev_mode(mut self, dev_mode: bool) -> Self {
+        self.dev_mode = dev_mode;
+        self
+    }
+
+    /// Turns the current builder into a valid `ViteHBSTemplateResolver`.
+    ///
+    /// # Panics
+    /// Panics if `vite` or `template_path` hasn't been set.
+    #[inline]
+    pub fn build(self) -> Result<ViteHBSTemplateResolver<'a>, InertiaError> {
+        ViteHBSTemplateResolver::from_builder(self)
+    }
+}
+
+#[async_trait(?Send)]
+impl TemplateResolver for ViteHBSTemplateResolver<'_> {
+    async fn resolve_template(&self, view_data: ViewData<'_>) -> Result<String, InertiaError> {
+        let (inertia_head, inertia_body) = match view_data.ssr_page {
+            Some(ssr_page) => (ssr_page.get_head(), ssr_page.get_body()),
+            None => {
+                let stringified_page = match serde_json::to_string(&view_data.page) {
+                    Ok(page) => page,
+                    Err(_) => {
+                        return Err(InertiaError::SerializationError(format!(
+                            "Failed to serialize view_data.page: {:?}",
+                            &view_data.page
+                        )))
+                    }
+                };
+
+                let container = format!("<div id='app' data-page='{}'></div>\n", stringified_page,);
+
+                (String::new(), container)
+            }
+        };
+
+        let data = json!({
+            "inertia_head": inertia_head,
+            "inertia_body": inertia_body,
+            "page": view_data.page.get_props(),
+            "view_data": view_data.custom_props,
+            "vite": self.static_tags.scripts,
+            "vite_react_refresh": self.static_tags.react_script
+        });
+
+        self.hbs.render("root", &data).map_err(|err| {
+            InertiaError::RenderError(format!(
+                "Could not render page due to Handlebars error: {}",
+                err.reason()
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ViteHBSTemplateResolver;
+    use crate::{
+        hashmap, template_resolver::TemplateResolver, Inertia, InertiaConfigBuilder, InertiaPage,
+        InertiaSSRPage, InertiaVersion, ViewData,
+    };
+    use serde_json::{json, Map};
+    use vite_rust::{Vite, ViteConfig, ViteMode};
+
+    async fn get_inertia<T: TemplateResolver + Send + Sync + 'static>(
+        template_resolver: T,
+    ) -> Inertia {
+        Inertia::new(
+            InertiaConfigBuilder::new()
+                .set_url("http://localhost:3000")
+                .set_version(InertiaVersion::Literal("1"))
+                .set_template_resolver(Box::new(template_resolver))
+                .build(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn render_on_dev_mode() {
+        let vite = Vite::new(
+            ViteConfig::new("tests/common/manifest.json", vec!["www/app.tsx"])
+                .set_force_mode(ViteMode::Development),
+        )
+        .await
+        .unwrap();
+
+        let template_resolver =
+            ViteHBSTemplateResolver::new(vite, "tests/common/root_layout.hbs", true).unwrap();
+
+        let inertia = get_inertia(template_resolver).await;
+
+        let page = InertiaPage {
+            clear_history: false,
+            encrypt_history: false,
+            component: "Index".into(),
+            deferred_props: None,
+            merge_props: None,
+            props: Map::from_iter(hashmap![
+                "user".into() => json!({
+                    "name": "John Doe",
+                    "age": 25,
+                })
+            ]),
+            url: inertia.url,
+            version: Some(inertia.get_version()),
+        };
+
+        let view_data = ViewData {
+            custom_props: Map::from_iter(hashmap!["ssr".into() => false.into()]),
+            page,
+            ssr_page: None,
+        };
+
+        let result = inertia.template_resolver.resolve_template(view_data).await;
+
+        assert!(result.is_ok());
+
+        let page = result.unwrap();
+
+        assert_eq!(
+            page.replace("    ", "").replace("\r\n", "\n").trim(),
+            r#"<!doctype html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+                <meta http-equiv="X-UA-Compatible" content="ie=edge">
+                <meta name="ssr" value="false">
+                <title inertia>John Doe</title>
+                <script type="module">
+                            import RefreshRuntime from 'http://localhost:5173/@react-refresh'
+                            RefreshRuntime.injectIntoGlobalHook(window)
+                            window.$RefreshReg$ = () => {}
+                            window.$RefreshSig$ = () => (type) => type
+                            window.__vite_plugin_react_preamble_installed__ = true
+                        </script>
+                <script type="module" src="http://localhost:5173/www/app.tsx"></script>
+            <script type="module" src="http://localhost:5173/@vite/client"></script>
+
+            </head>
+            <body>
+            <div id='app' data-page='{"component":"Index","props":{"user":{"age":25,"name":"John Doe"}},"url":"http://localhost:3000","version":"1","clearHistory":false,"encryptHistory":false}'></div>
+
+            </body>
+            </html>
+            "#.replace("    ", "").replace("\r\n", "\n").trim()
+        );
+    }
+
+    #[tokio::test]
+    async fn render_on_manifest_mode() {
+        let vite = Vite::new(
+            ViteConfig::new("tests/common/manifest.json", vec!["www/app.tsx"])
+                .set_force_mode(ViteMode::Manifest),
+        )
+        .await
+        .unwrap();
+
+        let template_resolver =
+            ViteHBSTemplateResolver::new(vite, "tests/common/root_layout.hbs", false).unwrap();
+
+        let inertia = get_inertia(template_resolver).await;
+
+        let page = InertiaPage {
+            clear_history: false,
+            encrypt_history: false,
+            component: "Index".into(),
+            deferred_props: None,
+            merge_props: None,
+            props: Map::from_iter(hashmap![
+                "user".into() => json!({
+                    "name": "John Doe",
+                    "age": 25,
+                })
+            ]),
+            url: inertia.url,
+            version: Some(inertia.get_version()),
+        };
+
+        let view_data = ViewData {
+            custom_props: Map::from_iter(hashmap!["ssr".into() => true.into()]),
+            page,
+            ssr_page: Some(InertiaSSRPage {
+                body: "<h1>Hello John Doe!</h1><p>You are 25 years old.</p>".into(),
+                head: vec![
+                    "<title inertia>Hello World John Doe</title>".into(),
+                    r#"<meta name="description" content="Pretty interesting page description""#
+                        .into(),
+                ],
+            }),
+        };
+
+        let result = inertia.template_resolver.resolve_template(view_data).await;
+
+        assert!(result.is_ok());
+
+        let page = result.unwrap();
+
+        assert_eq!(
+            page.replace("    ", "").replace("\r\n", "\n").replace("\n\n", "\n").trim(),
+            r#"<!doctype html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+                <meta http-equiv="X-UA-Compatible" content="ie=edge">
+                <meta name="ssr" value="true">
+                <title inertia>John Doe</title>
+                <link rel="stylesheet" href="assets/app-BoNdGpDJ.css" />
+                <script type="module" src="assets/app-CEfUlegz.js"></script>
+                <title inertia>Hello World John Doe</title>
+                <meta name="description" content="Pretty interesting page description"
+            </head>
+            <body>
+                <h1>Hello John Doe!</h1><p>You are 25 years old.</p>
+            </body>
+            </html>"#.replace("    ", "").replace("\r\n", "\n").replace("\n\n", "\n").trim()
+        )
+    }
+}

--- a/src/features/template_resolvers/vite_template_resolver.rs
+++ b/src/features/template_resolvers/vite_template_resolver.rs
@@ -2,41 +2,29 @@ use crate::{template_resolver::TemplateResolver, InertiaError, ViewData};
 use async_trait::async_trait;
 use regex::Regex;
 use serde_json::{to_value, Map, Value};
-use std::{path::Path, sync::OnceLock};
+use std::sync::OnceLock;
 use vite_rust::{features::html_directives::ViteDefaultDirectives, Vite};
 
 static INERTIA_VIEW_DATA_REGEX: OnceLock<Regex> = OnceLock::new();
 
 pub struct ViteTemplateResolver {
     pub vite: Vite,
+    pub root_template: &'static str,
 }
 
 impl ViteTemplateResolver {
-    pub fn new(vite: Vite) -> Self {
-        Self { vite }
-    }
-}
-
-#[async_trait(?Send)]
-impl TemplateResolver for ViteTemplateResolver {
-    async fn resolve_template(
-        &self,
-        template_path: &str,
-        view_data: ViewData<'_>,
-    ) -> Result<String, InertiaError> {
-        let path = Path::new(template_path);
-        let file = match tokio::fs::read(&path).await {
+    pub fn new(vite: Vite, template_path: &str) -> Result<Self, InertiaError> {
+        let file = match std::fs::read(template_path) {
             Ok(file) => file,
             Err(err) => {
                 return Err(InertiaError::RenderError(format!(
                     "Failed to open root layout at {}: {:#}",
-                    path.to_str().unwrap(),
-                    err
+                    template_path, err
                 )))
             }
         };
 
-        let mut html = match String::from_utf8(file) {
+        let html = match String::from_utf8(file) {
             Err(err) => {
                 return Err(InertiaError::RenderError(format!(
                     "Failed to read file contents: {err:?}"
@@ -44,6 +32,18 @@ impl TemplateResolver for ViteTemplateResolver {
             }
             Ok(html) => html,
         };
+
+        Ok(Self {
+            vite,
+            root_template: Box::leak(html.into_boxed_str()),
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl TemplateResolver for ViteTemplateResolver {
+    async fn resolve_template(&self, view_data: ViewData<'_>) -> Result<String, InertiaError> {
+        let mut html = self.root_template.to_string();
 
         if let Err(err) = self.vite.vite_directive(&mut html) {
             log::warn!("Failed to resolve vite directive: {}", err);

--- a/src/features/template_resolvers/vite_template_resolver.rs
+++ b/src/features/template_resolvers/vite_template_resolver.rs
@@ -1,3 +1,9 @@
+//! You probably would be better not using this Template Resolver.
+//! It uses regex for resolving every supported directive, which can lead to slower rendering.
+//! Instead, you should use [`ViteHBSTemplateResolver`] with Handlebars.
+//!
+//! [`ViteHBSTemplateResolver`]: crate::features::template_resolvers::ViteHBSTemplateResolver
+#![allow(deprecated)]
 use crate::{template_resolver::TemplateResolver, InertiaError, ViewData};
 use async_trait::async_trait;
 use regex::Regex;
@@ -7,6 +13,19 @@ use vite_rust::{features::html_directives::ViteDefaultDirectives, Vite};
 
 static INERTIA_VIEW_DATA_REGEX: OnceLock<Regex> = OnceLock::new();
 
+/// The most simplory template resolver. It uses Vite Rust for assets bundling and
+/// with its basic html directives plus naive regex replacements for handling
+/// Inertia specific directives.
+///
+/// While it allows you to use simple html files as root template, you would be
+/// best armed by using [`ViteHBSTemplateResolver`] (which uses handlebars instead
+/// of Regex \[which isn't even a template engine at all\]).
+///
+/// [`ViteHBSTemplateResolver`]: crate::features::template_resolvers::ViteHBSTemplateResolver
+#[deprecated(
+    since = "2.4.0",
+    note = "`ViteTemplateResolver` leads to slow rendering, since it uses regex for resolving the directives. Replace it with `ViteHBSTemplateResolver`."
+)]
 pub struct ViteTemplateResolver {
     pub vite: Vite,
     pub root_template: &'static str,

--- a/src/features/template_resolvers/vite_template_resolver.rs
+++ b/src/features/template_resolvers/vite_template_resolver.rs
@@ -57,7 +57,7 @@ impl TemplateResolver for ViteTemplateResolver {
 
         match &view_data.ssr_page {
             Some(ssr) => {
-                html = html.replace("@inertia::body", ssr.get_body());
+                html = html.replace("@inertia::body", &ssr.get_body());
                 html = html.replace("@inertia::head", &ssr.get_head());
             }
             None => {

--- a/src/inertia.rs
+++ b/src/inertia.rs
@@ -160,8 +160,6 @@ pub struct Inertia {
     /// URL used between redirects and responses generation, i.g. "https://myapp.com".
     #[allow(unused)]
     pub(crate) url: &'static str,
-    /// The path to find the root html template to render everything in.
-    pub(crate) template_path: &'static str,
     /// The current assets version.
     pub(crate) version: &'static str,
     /// A struct that implements [TemplateResolver] trait.
@@ -211,7 +209,6 @@ impl Inertia {
 
         Ok(Self {
             url: config.url,
-            template_path: config.template_path,
             version,
             template_resolver: config.template_resolver,
             ssr_url,
@@ -253,7 +250,6 @@ impl Inertia {
     ///     impl TemplateResolver for MyTemplateResolver {
     ///         async fn resolve_template(
     ///             &self,
-    ///             template_path: &str,
     ///             view_data: ViewData<'_>,
     ///         ) -> Result<String, InertiaError> {
     ///             // import the layout root and render it using your template engine
@@ -267,7 +263,6 @@ impl Inertia {
     ///             .set_url("https://www.my-web-app.com")
     ///             .set_version(InertiaVersion::Literal("my-assets-version"))
     ///             .set_template_resolver(Box::new(MyTemplateResolver))
-    ///             .set_template_path("www/index.html")
     ///             .build()
     ///     )
     ///     .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,8 @@ pub mod actix {
     pub use super::providers::actix::SessionErrors;
 }
 
-#[cfg(feature = "vite-template-resolver")]
 pub mod template_resolvers {
-    pub use super::features::template_resolvers::ViteTemplateResolver;
+    pub use super::features::template_resolvers::*;
     pub use super::template_resolver::TemplateResolver;
 }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -35,8 +35,9 @@ impl InertiaSSRPage {
     pub fn get_head(&self) -> String {
         self.head.join("\n")
     }
-    pub fn get_body(&self) -> &String {
-        &self.body
+
+    pub fn get_body(&self) -> String {
+        self.body.clone()
     }
 }
 

--- a/src/providers/actix_provider/impls.rs
+++ b/src/providers/actix_provider/impls.rs
@@ -365,9 +365,7 @@ impl Inertia {
     }
 
     async fn render_page(&self, view_data: ViewData<'_>) -> Result<String, InertiaError> {
-        self.template_resolver
-            .resolve_template(self.template_path, view_data)
-            .await
+        self.template_resolver.resolve_template(view_data).await
     }
 
     fn send_response(&self, mut response: HttpResponse) -> HttpResponse {
@@ -488,11 +486,7 @@ mod test {
 
     #[async_trait::async_trait(?Send)]
     impl TemplateResolver for MyTemplateResolver {
-        async fn resolve_template(
-            &self,
-            _path: &str,
-            view_data: ViewData<'_>,
-        ) -> Result<String, InertiaError> {
+        async fn resolve_template(&self, view_data: ViewData<'_>) -> Result<String, InertiaError> {
             // import the layout root using your favourite engine
             // and renders it passing to it the view_data!
             let page = view_data.page;
@@ -509,7 +503,6 @@ mod test {
             InertiaConfig::builder()
                 .set_url("https://my-inertia-website.com")
                 .set_version(InertiaVersion::Resolver(Box::new(|| "gen_the_version")))
-                .set_template_path("/resources/view/template.hbs")
                 .set_template_resolver(Box::new(MyTemplateResolver))
                 .build(),
         )

--- a/src/providers/actix_provider/impls.rs
+++ b/src/providers/actix_provider/impls.rs
@@ -345,6 +345,7 @@ impl Inertia {
             .unwrap_or_default();
 
         custom_view_data.insert("isSsr".into(), is_ssr.into());
+        custom_view_data.insert("is_ssr".into(), is_ssr.into());
 
         custom_view_data
     }

--- a/src/template_resolver.rs
+++ b/src/template_resolver.rs
@@ -14,7 +14,6 @@ pub trait TemplateResolver {
     ///
     /// # Arguments
     /// Inertia will call this function passing the following parameters to it:
-    /// * `path`        -   The path to the application template (`Inertia::template_path`).
     /// * `view_data`   -   A [`ViewData`] struct,
     ///
     /// # Errors
@@ -23,9 +22,5 @@ pub trait TemplateResolver {
     /// # Return
     /// The return must be the template rendered to HTML. It will be sent as response to full
     /// requests.
-    async fn resolve_template(
-        &self,
-        path: &str,
-        view_data: ViewData<'_>,
-    ) -> Result<String, InertiaError>;
+    async fn resolve_template(&self, view_data: ViewData<'_>) -> Result<String, InertiaError>;
 }

--- a/tests/common/manifest.json
+++ b/tests/common/manifest.json
@@ -1,0 +1,11 @@
+{
+    "www/app.tsx": {
+        "file": "assets/app-CEfUlegz.js",
+        "name": "app",
+        "src": "www/app.tsx",
+        "isEntry": true,
+        "css": [
+        "assets/app-BoNdGpDJ.css"
+        ]
+    }
+}

--- a/tests/common/root_layout.hbs
+++ b/tests/common/root_layout.hbs
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="ssr" value="{{ view_data.ssr }}">
+    <title inertia>{{ page.user.name }}</title>
+    {{{ vite_react_refresh }}}
+    {{{ vite }}}
+    {{{ inertia_head }}}
+</head>
+<body>
+    {{{ inertia_body }}}
+</body>
+</html>

--- a/tests/common/template_resolver.rs
+++ b/tests/common/template_resolver.rs
@@ -53,37 +53,34 @@ pub fn get_dynamic_csr_with_view_data_expect(
     ))
 }
 
-pub struct MockedTemplateResolver;
+pub struct MockedTemplateResolver {
+    root_template: String,
+}
+
+impl MockedTemplateResolver {
+    pub fn new(template_path: &str) -> Result<Self, InertiaError> {
+        let path = Path::new(template_path);
+
+        let file_data = std::fs::read(path).map_err(|err| {
+            InertiaError::RenderError(format!(
+                "Failed to open root layout at {}: {:#}",
+                path.to_str().unwrap(),
+                err
+            ))
+        })?;
+
+        let root_template = String::from_utf8(file_data).map_err(|err| {
+            InertiaError::RenderError(format!("Failed to read file contents: {err:?}"))
+        })?;
+
+        Ok(Self { root_template })
+    }
+}
 
 #[async_trait(?Send)]
 impl TemplateResolver for MockedTemplateResolver {
-    async fn resolve_template(
-        &self,
-        template_path: &str,
-        view_data: ViewData<'_>,
-    ) -> Result<String, InertiaError> {
-        let path = Path::new(template_path);
-
-        let read_file = tokio::fs::read(&path).await;
-
-        if read_file.is_err() {
-            return Err(InertiaError::SsrError(format!(
-                "Failed to open root layout at {}: {:#}",
-                path.to_str().unwrap(),
-                read_file.unwrap_err()
-            )));
-        }
-
-        let data = read_file.unwrap();
-
-        let mut html = match String::from_utf8(data) {
-            Err(err) => {
-                return Err(InertiaError::SsrError(format!(
-                    "Failed to read file contents: {err:?}"
-                )))
-            }
-            Ok(html) => html,
-        };
+    async fn resolve_template(&self, view_data: ViewData<'_>) -> Result<String, InertiaError> {
+        let mut html = self.root_template.clone();
 
         html = html.replace(
             "%-view_data_title-%",

--- a/tests/common/template_resolver.rs
+++ b/tests/common/template_resolver.rs
@@ -103,7 +103,7 @@ impl TemplateResolver for MockedTemplateResolver {
 
         match view_data.ssr_page {
             Some(ssr) => {
-                html = html.replace("%-inertia_body-%", ssr.get_body());
+                html = html.replace("%-inertia_body-%", &ssr.get_body());
                 html = html.replace("%-inertia_head-%", &ssr.get_head());
             }
             None => {

--- a/tests/test_p_actix.rs
+++ b/tests/test_p_actix.rs
@@ -58,8 +58,9 @@ fn get_inertia_config() -> InertiaConfigBuilder<&'static str> {
     InertiaConfig::builder()
         .set_url("https://inertiajs.com")
         .set_version(InertiaVersion::Literal(TEST_INERTIA_VERSION))
-        .set_template_path("tests/common/root_layout.html")
-        .set_template_resolver(Box::new(MockedTemplateResolver))
+        .set_template_resolver(Box::new(
+            MockedTemplateResolver::new("tests/common/root_layout.html").unwrap(),
+        ))
 }
 
 fn maybe_initialize_sessions_storage() {


### PR DESCRIPTION
This PR does:
- Move `template_path` field from `Inertia` configuration to template resolvers;
- Add new `ViteHBSTemplateResolver`, which uses Vite Rust + Handlebars to resolve the templates;
- Deprecate `ViteTemplateResolver` (which uses Regexes as a "template engine" and thus is pretty slow and inneficient);
- Update the documentations to introduce the new template resolver and discourage the deprecated one;
- Update the example application to use the new template resolver;
- Add the changes to the changelog, under the unreleased section;
- Make `regex` crate optional;
- Make `basic-vite-directives` feature from `vite-rust` crate optionally enabled by the `vite-template-resolver` only;
- Add `handlebars` as optional crate (enabled by `vite-hbs-template-resolver` feature).