### PR TITLE
feat: add `check_is_inertia_request` facade method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Exposes inner `InertiaHttpRequest::is_inertia_request` through facade method `Inertia::check_is_inertia_request`.
 
 ## v2.4.5
 ### Changed

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -75,4 +75,7 @@ pub trait InertiaFacade<THttpRequest, TResponse, TRedirect> {
 
     /// Inserts custom view data to be accessed by the template root.
     fn view_data(req: &THttpRequest, data: HashMap<&str, Value>);
+
+    /// Checks whether the request was made by the Inertia client router rather than a standard full-page load.
+    fn check_is_inertia_request(req: &THttpRequest) -> bool;
 }

--- a/src/providers/actix_provider/facade.rs
+++ b/src/providers/actix_provider/facade.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::facade::InertiaFacade;
-use crate::inertia::{InertiaResponder, X_INERTIA, X_INERTIA_LOCATION};
+use crate::inertia::{InertiaHttpRequest, InertiaResponder, X_INERTIA, X_INERTIA_LOCATION};
 use crate::{Component, Inertia, InertiaError, InertiaProps};
 use actix_web::dev::ServiceResponse;
 use actix_web::web::{Data, Redirect};
@@ -63,6 +63,11 @@ impl InertiaFacade<HttpRequest, HttpResponse, Redirect> for Inertia {
         ));
 
         req.extensions_mut().insert(custom_view_data);
+    }
+
+    #[inline]
+    fn check_is_inertia_request(req: &HttpRequest) -> bool {
+        req.is_inertia_request()
     }
 }
 


### PR DESCRIPTION
Added the `Inertia::check_is_inertia_request` facade method to access `InertiaHttpResponse::is_inertia_request` without exposing the whole inner `InertiaHttpResponse` trait.